### PR TITLE
Fix trailing zero bit mask.

### DIFF
--- a/scroll_to_ome.py
+++ b/scroll_to_ome.py
@@ -374,13 +374,13 @@ def preprocess_tiff(inttiffs, itiff, standard_config):
             tiff = (tiff/256).astype(np.uint8)
             # Zero 8 - n bits
             trailing_zero_bits = 8 - standard_config['n_bits']
-            bit_mask = int(2**8 - 1 - 2**trailing_zero_bits)
+            bit_mask = int(2**8 - 2**trailing_zero_bits)
         else:
             # To uint16
             tiff = tiff.astype(np.uint16)
             # Zero 16 - n bits
             trailing_zero_bits = 16 - standard_config['n_bits']
-            bit_mask = int(2**16 - 1 - 2**trailing_zero_bits)
+            bit_mask = int(2**16 - 2**trailing_zero_bits)
         tiff = (tiff & bit_mask).astype(tiff.dtype)
         tiff = tiff.astype(np.uint16) * 255 # Debug ONLY with Khartes
     return tiff


### PR DESCRIPTION
The trailing zero bit mask (`0b11110111`) was zeroing the incorrect bits: bit 3 instead of bits 0 - 2 or up to the number of trailing zero bits. The default bit mask (`0b11111000`) should now be correct.

The result is better compression on disk. A 20 tiff Zarr volume was compressed from 702 MB to 466 MB or 66% of its original size. The apparent image quality is similar, at least to my eyes.

This work is intended to address this issue: https://github.com/ScrollPrize/vesuvius/issues/4

### Before and After Comparison
![Figure_1](https://github.com/user-attachments/assets/7ba29833-34ec-4291-ad66-0e3afa0a08ed)
